### PR TITLE
ScreenLock property misspelled

### DIFF
--- a/lib/src/screen_lock.dart
+++ b/lib/src/screen_lock.dart
@@ -27,7 +27,7 @@ class ScreenLock extends StatefulWidget {
     this.didError,
     this.maxRetries = 0,
     this.didMaxRetries,
-    this.custmizedButtonTap,
+    this.customizedButtonTap,
     this.customizedButtonChild,
     this.footer,
     this.cancelButton,
@@ -84,7 +84,7 @@ class ScreenLock extends StatefulWidget {
   final void Function(int retries)? didMaxRetries;
 
   /// Tapped for left side lower button.
-  final Future<void> Function()? custmizedButtonTap;
+  final Future<void> Function()? customizedButtonTap;
 
   /// Child for bottom left side button.
   final Widget? customizedButtonChild;


### PR DESCRIPTION
This is a breaking change, but customizedButtonTap was missing the 'o' in 'customized'