### PR TITLE
Clear input chars on long pressed

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -55,6 +55,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:

--- a/lib/src/buttons/delete_button.dart
+++ b/lib/src/buttons/delete_button.dart
@@ -7,8 +7,9 @@ class DeleteButton extends StyledInputButton {
     Key? key,
     this.child,
     required void Function() onPressed,
+    void Function()? onLongPress,
     InputButtonConfig config = const InputButtonConfig(),
-  }) : super(key: key, onPressed: onPressed, config: config);
+  }) : super(key: key, onPressed: onPressed, config: config, onLongPress: onLongPress);
 
   final Widget? child;
 
@@ -22,6 +23,8 @@ class DeleteButton extends StyledInputButton {
   @override
   Widget build(BuildContext context) {
     return makeKeyContainer(
-        child: child ?? const Icon(Icons.backspace), context: context);
+      child: child ?? const Icon(Icons.backspace),
+      context: context,
+    );
   }
 }

--- a/lib/src/buttons/styled_input_button.dart
+++ b/lib/src/buttons/styled_input_button.dart
@@ -7,10 +7,12 @@ abstract class StyledInputButton extends StatelessWidget {
     Key? key,
     this.config = const StyledInputConfig(),
     required this.onPressed,
+    this.onLongPress,
   }) : super(key: key);
 
   final StyledInputConfig config;
   final void Function() onPressed;
+  final void Function()? onLongPress;
 
   double computeHeight(Size boxSize) {
     if (config.autoSize) {
@@ -52,8 +54,10 @@ abstract class StyledInputButton extends StatelessWidget {
     return config.buttonStyle ?? OutlinedButton.styleFrom();
   }
 
-  Widget makeKeyContainer(
-      {required BuildContext context, required Widget child}) {
+  Widget makeKeyContainer({
+    required BuildContext context,
+    required Widget child,
+  }) {
     final boxSize = defaultSize(context);
     return Container(
       height: computeHeight(boxSize),
@@ -61,6 +65,7 @@ abstract class StyledInputButton extends StatelessWidget {
       margin: const EdgeInsets.all(10),
       child: OutlinedButton(
         onPressed: onPressed,
+        onLongPress: onLongPress,
         child: child,
         style: makeDefaultStyle(),
       ),

--- a/lib/src/configurations/input_button_config.dart
+++ b/lib/src/configurations/input_button_config.dart
@@ -40,7 +40,7 @@ class InputButtonConfig extends StyledInputConfig {
       '6',
       '7',
       '8',
-      '9'
+      '9',
     ],
     this.displayStrings = const [
       '0',
@@ -52,8 +52,9 @@ class InputButtonConfig extends StyledInputConfig {
       '6',
       '7',
       '8',
-      '9'
+      '9',
     ],
+    this.clearOnLongPressed = false,
   }) : super(
           autoSize: autoSize,
           height: height,
@@ -70,4 +71,5 @@ class InputButtonConfig extends StyledInputConfig {
   final TextStyle? textStyle;
   final List<String> inputStrings;
   final List<String> displayStrings;
+  final bool clearOnLongPressed;
 }

--- a/lib/src/layout/key_pad.dart
+++ b/lib/src/layout/key_pad.dart
@@ -49,6 +49,7 @@ class KeyPad extends StatelessWidget {
           return DeleteButton(
             child: deleteButton,
             onPressed: () => inputState.removeCharacter(),
+            onLongPress: inputButtonConfig.clearOnLongPressed ? () => inputState.clear() : null,
           );
         }
       },

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -130,6 +130,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -204,7 +211,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
This feature is good for user experience in which they don't have to clear characters one by one.

**Usage:**
clearOnLongPressed is `false` by default, so it doesn't affect old package users who don't need it.
```dart
inputButtonConfig = InputButtonConfig(
  clearOnLongPressed: true,
  ...
);
```

https://user-images.githubusercontent.com/29684683/154835089-db4ce07f-7df5-473a-a1d8-00cd1a688a52.mp4