### PR TITLE
Fixed setState running after screenlock dispose

### DIFF
--- a/lib/src/screen_lock.dart
+++ b/lib/src/screen_lock.dart
@@ -172,6 +172,7 @@ class _ScreenLockState extends State<ScreenLock> {
     Timer.periodic(const Duration(milliseconds: 100), (timer) {
       if (!mounted) {
         timer.cancel();
+        return;
       }
 
       Duration difference = unlockTime.difference(DateTime.now());


### PR DESCRIPTION
We still have to return inside of this if statement.
Otherwise, the rest of it is evaluated, and setState can be called.
setState should not be called when we are not `mounted`